### PR TITLE
Pj/fix/responsive css

### DIFF
--- a/frontend/src/components/FeedColumn/FeedColumn.tsx
+++ b/frontend/src/components/FeedColumn/FeedColumn.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { PostProps } from "../../types/post.types";
 import axios from "axios";
 
-const FeedColumn: React.FC<PostProps> = () => {
+const FeedColumn = () => {
   const [feedPosts, setFeedPosts] = useState<PostProps[]>([]);
 
   async function getPosts() {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -44,13 +44,13 @@ body {
 /* RESPONSIVE CSS */
 
 @media (max-width: 1200px) {
-  .sign-up-benefits-container {
+  .signup-benefits-wrapper {
     display: none;
   }
 }
 
 @media (max-width: 900px) {
-  .category-selector-box {
+  .category-selector-wrapper {
     display: none;
   }
 }


### PR DESCRIPTION
Noticed the responsive CSS was broken by changes to scroll so changed the elements that get hidden.
VSCode was unhappy about FeedColumn as there were still prop types being declared but no props so I deleted them.
Everything looks good. Navbar looks much better. Feels like everything is to big like we are using Duplo instead of Lego but we can work those out as we go 😄