### PR TITLE
Extension of postContext to give a provider and custom hook

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,24 +1,21 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import FeedPage from "./pages/FeedPage/FeedPage";
 import Navbar from "./components/Navbar/Navbar";
-import PostContext from "./context/PostContext";
-import { useState } from "react";
-import { PostObject } from "./types/post.types";
+import {PostProvider} from "./context/PostProvider";
 
 function App() {
-  const [feedPosts, setFeedPosts] = useState<PostObject[]>([]);
-  
+
   return (
     <BrowserRouter>
-      <PostContext.Provider value={{feedPosts, setFeedPosts}}>
-      <div id="app">
-        <Navbar />
-        {/* <div className="navbar-spacer"></div> */}
-        <Routes>
-          <Route path="/" element={<FeedPage />} />
-        </Routes>
+      <PostProvider>
+        <div id="app">
+          <Navbar />
+          {/* <div className="navbar-spacer"></div> */}
+          <Routes>
+            <Route path="/" element={<FeedPage />} />
+          </Routes>
         </div>
-      </PostContext.Provider>
+      </PostProvider>
     </BrowserRouter>
   );
 }

--- a/frontend/src/components/FeedColumn/FeedColumn.tsx
+++ b/frontend/src/components/FeedColumn/FeedColumn.tsx
@@ -1,54 +1,37 @@
 import "./FeedColumn.css";
 import PostItem from "../PostItem/PostItem";
-import { useEffect, useContext } from "react";
+import { useEffect } from "react";
 import { PostObject } from "../../types/post.types";
-import axios from "axios";
-import baseUrl from "../../utils/baseUrl";
-import PostContext from "../../context/PostContext";
+import { usePostContext } from "../../context/usePostContext";
 
 const FeedColumn = () => {
-  const contextValue = useContext(PostContext);
-
-  const feedPosts = contextValue?.feedPosts;
-  const setFeedPosts = contextValue?.setFeedPosts;
-
-  async function getPosts() {
-    try {
-      const response = await axios.get(`${baseUrl}/api/v1.0/posts`);
-      if (response.status !== 200) {
-        throw new Error("Error in network response");
-      }
-      const posts = response.data;
-      setFeedPosts && setFeedPosts(posts);
-    } catch (error) {
-      console.error("Error fetching posts:", error);
-    }
-  }
+  const {feedPosts, getPosts} = usePostContext();
 
   useEffect(() => {
     getPosts();
-  }, []);
+  }, [getPosts]);
 
   return (
     <div className="feed-col-container">
       <h1 className="feed-title">FixIt news feed</h1>
       <div className="main-feed-container">
-        {feedPosts && feedPosts.map((post: PostObject) => (
-          <div key={post.postId}>
-            <PostItem
-              postId={post.postId}
-              postAuthor={post.postAuthor}
-              postText={post.postText}
-              tags={post.tags}
-              comments={post.comments}
-              images={post.images}
-              videos={post.videos}
-              votes={post.votes}
-              createdAt={post.createdAt}
-            />
-            <div className="horizontal-divider feed-divider"></div>
-          </div>
-        ))}
+        {feedPosts &&
+          feedPosts.map((post: PostObject) => (
+            <div key={post.postId}>
+              <PostItem
+                postId={post.postId}
+                postAuthor={post.postAuthor}
+                postText={post.postText}
+                tags={post.tags}
+                comments={post.comments}
+                images={post.images}
+                videos={post.videos}
+                votes={post.votes}
+                createdAt={post.createdAt}
+              />
+              <div className="horizontal-divider feed-divider"></div>
+            </div>
+          ))}
       </div>
       <div className="footer-bit"></div>
     </div>

--- a/frontend/src/context/PostContext.tsx
+++ b/frontend/src/context/PostContext.tsx
@@ -1,8 +1,0 @@
-import { createContext } from "react";
-import { PostObject } from "../types/post.types";
-
-type PostContextType = { feedPosts: PostObject[]; setFeedPosts: React.Dispatch<React.SetStateAction<PostObject[]>>; } | null;
-
-const PostContext = createContext<PostContextType>(null);
-
-export default PostContext;

--- a/frontend/src/context/PostProvider.tsx
+++ b/frontend/src/context/PostProvider.tsx
@@ -1,0 +1,37 @@
+import { createContext, useState } from "react";
+import { PostObject } from "../types/post.types";
+import axios from "axios";
+import baseUrl from "../utils/baseUrl";
+
+// NOTE: IN theory, we do not need stFeedPosts anymore except in this file but I am leaving as an export for future ease until we are sure.
+
+interface PostContextType {
+  feedPosts: PostObject[];
+  setFeedPosts: React.Dispatch<React.SetStateAction<PostObject[]>>;
+  getPosts: () => Promise<void>;
+}
+
+export const PostContext = createContext<PostContextType>({ feedPosts: [], setFeedPosts: () => {}, getPosts: async () => {} });
+
+export const PostProvider = ({ children }: { children: React.ReactNode }) => {
+  const [feedPosts, setFeedPosts] = useState<PostObject[]>([]);
+
+  const getPosts = async () => {
+    try {
+      const response = await axios.get(`${baseUrl}/api/v1.0/posts`);
+      if (response.status !== 200) {
+        throw new Error("Error in network response");
+      }
+      const posts = response.data;
+      setFeedPosts && setFeedPosts(posts);
+    } catch (error) {
+      console.error("Error fetching posts:", error);
+    }
+  }
+
+  return (
+    <PostContext.Provider value={{ feedPosts, setFeedPosts, getPosts }}>
+      {children}
+    </PostContext.Provider>
+  );
+}

--- a/frontend/src/context/usePostContext.ts
+++ b/frontend/src/context/usePostContext.ts
@@ -1,0 +1,10 @@
+import { useContext } from "react";
+import { PostContext } from "./PostProvider";
+
+export const usePostContext = () => {
+  const context = useContext(PostContext);
+  if (context === undefined) {
+    throw new Error("usePostContext must be used within a PostProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
I was getting complaints about exporting the custom hook as it might interfere with React fast refresh so moved it into a separate file.

All seems to work fine.

I suspect get posts will turn into a versatile fetch function with optional parameters for filtering, etc.